### PR TITLE
Remove space before 'px'

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -240,7 +240,7 @@ img {
 .U8d2H {
     font-family: Monaco,Menlo,Consolas,"Courier New",monospace !important;
     background-color: #f7f7f9;
-    margin: 0 px;
+    margin: 0px;
     padding: 1px 3px;
     color: #d72b3f;
     -webkit-border-radius: 3px;


### PR DESCRIPTION
I don't know if this makes any difference to the CSS at all, but Stylish was complaining about it.