### PR TITLE
Patch emoji dimension fix that breaks room titles containing emoji

### DIFF
--- a/css/shape.css
+++ b/css/shape.css
@@ -216,8 +216,6 @@ img {
 
 /* Fix emojis dimensions */
 .iiJ4W {
-    height: auto;
-    width: auto;
     max-height: 1.2em;
     max-width: 1.2em;
     min-width: auto;


### PR DESCRIPTION
Fixes #12 

Tested on the following platforms:
- Firefox 75.0 (64-bit) on Linux
- Google Chrome version 80.0.3987.122 (64-bit) on Linux