### PR TITLE
Remove height miscalculation causing overflow

### DIFF
--- a/css/shape.css
+++ b/css/shape.css
@@ -40,9 +40,6 @@ svg.GfYBMd.Kol3Vd.V3Pk2 {
 .HyiAVd, .i5PBGe .GVSFtd {
     margin-top: -5px;
 }
-.bn .bl {
-    height: calc(100vh -  36px );
-}
 
 /* Reduce height of search field in header bar */
 .gb_Ue {


### PR DESCRIPTION
The reply button or reply box can overflow in GHC standalone website.
This is due to the .bn .bl height override, which does not seem to work
for standalone website but it sounds like does work for gmail (maybe the selector does not apply to gmail?).

Perhaps there can be different overrides per website, or, this override
should be removed entirely or adjusted to work for both.

This removes it entirely, which will increase some empty space but
also increase usability.

Maybe more could be done to remove that little border at that bottom to
reduce whitespace.